### PR TITLE
Find correct project in asana-github integration action

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,13 @@ This action integrates asana with github.
 
 **Optional** If any comment is provided, the action will add a comment to the specified asana task with the text & pull request link.
 
+### `target-project`
+
+**Optional** Move task only if it exists in provided project i.e `Current Sprint`.
+
 ### `target-section`
 
-**Optional** Add/Move the task to the provided section i.e `merged`, `review`.
+**Optional** Add/Move the task to the provided section if provided section exists in `target-project` i.e `merged`, `review`.
 
 
 ## Example usage
@@ -33,6 +37,7 @@ This action integrates asana with github.
 uses: https://github.com/insurify/github-actions@master
 with:
   asana-pat: 'Your PAT'
+  target-project: 'Current Sprint'
   target-section: 'In Review'
   task-comment: 'View Pull Request Here: '
   trigger-phrase: 'Asana Task:'

--- a/README.md
+++ b/README.md
@@ -22,23 +22,22 @@ This action integrates asana with github.
 
 **Optional** If any comment is provided, the action will add a comment to the specified asana task with the text & pull request link.
 
-### `target-project`
+### `targets`
 
-**Optional** Move task only if it exists in provided project i.e `Current Sprint`.
-
-### `target-section`
-
-**Optional** Add/Move the task to the provided section if provided section exists in `target-project` i.e `merged`, `review`.
+**Optional** JSON array of objects having project and section where to move current task. Move task only if it exists in target project. e.g 
+```yaml
+targets: '[{"project": "Backlog", "section": "Development Done"}, {"project": "Current Sprint", "section": "In Review"}]'
+```
+if you don't want to move task omit `targets`.
 
 
 ## Example usage
 
 ```yaml
-uses: https://github.com/insurify/github-actions@master
+uses: https://github.com/insurify/github-actions@v2.0.0
 with:
   asana-pat: 'Your PAT'
-  target-project: 'Current Sprint'
-  target-section: 'In Review'
   task-comment: 'View Pull Request Here: '
   trigger-phrase: 'Asana Task:'
+  targets: '[{"project": "Backlog", "section": "Development Done"}, {"project": "Current Sprint", "section": "In Review"}]'
 ```

--- a/action.yml
+++ b/action.yml
@@ -7,11 +7,8 @@ inputs:
   task-comment:
     description: 'Provide text, which will add a comment with the pull request link to the asana task.'
     required: false
-  target-project:
-    description: 'Name of a project in which you want to move task from one section(column) to another(target-section).'
-    required: false
-  target-section:
-    description: 'Name of a section(column) of target-project where you want to move the task.'
+  targets:
+    description: 'JSON array of objects having project and section where to move current task. Move task only if it exists in target project.'
     required: false
   trigger-phrase:
     description: 'Prefix before the task i.e ASANA TASK: https://app.asana.com/1/2/3'

--- a/action.yml
+++ b/action.yml
@@ -7,8 +7,11 @@ inputs:
   task-comment:
     description: 'Provide text, which will add a comment with the pull request link to the asana task.'
     required: false
+  target-project:
+    description: 'Name of a project in which you want to move task from one section(column) to another(target-section).'
+    required: false
   target-section:
-    description: 'Provide the name of an Asana projects section or column where you want to move the task.'
+    description: 'Name of a section(column) of target-project where you want to move the task.'
     required: false
   trigger-phrase:
     description: 'Prefix before the task i.e ASANA TASK: https://app.asana.com/1/2/3'

--- a/index.js
+++ b/index.js
@@ -4,9 +4,8 @@ const asana = require('asana');
 
 async function asanaOperations(
   asanaPAT,
-  projectName,
+  targets,
   taskId,
-  sectionName,
   taskComment
 ) {
   try {
@@ -15,22 +14,23 @@ async function asanaOperations(
       logAsanaChangeWarnings: false
     }).useAccessToken(asanaPAT);
 
-    if (sectionName && projectName) {
-      let targetProject = await client.tasks.findById(taskId)
-        .then(task => task.projects.find(project => project.name === projectName));
+    const task = await client.tasks.findById(taskId);
+    
+    targets.forEach(async target => {
+      let targetProject = task.projects.find(project => project.name === target.project);
       if (targetProject) {
         let targetSection = await client.sections.findByProject(targetProject.gid)
-          .then(sections => sections.find(section => section.name === sectionName));
+          .then(sections => sections.find(section => section.name === target.section));
         if (targetSection) {
           await client.sections.addTask(targetSection.gid, { task: taskId });
-          core.info('Moved to: ' + targetSection.name);
+          core.info(`Moved to: ${target.project}/${target.section}`);
         } else {
-          core.error('Asana section ' + sectionName + ' not found.');
+          core.error(`Asana section ${target.section} not found.`);
         }
       } else {
-        core.error(`This task does not exist in "${projectName}" project`);
+        core.info(`This task does not exist in "${target.project}" project`);
       }
-    }
+    });
 
     if (taskComment) {
       await client.tasks.addComment(taskId, {
@@ -45,8 +45,7 @@ async function asanaOperations(
 
 try {
   const ASANA_PAT = core.getInput('asana-pat'),
-    PROJECT_NAME = core.getInput('target-project'),
-    SECTION_NAME = core.getInput('target-section'),
+    TARGETS = core.getInput('targets'),
     TRIGGER_PHRASE = core.getInput('trigger-phrase'),
     TASK_COMMENT = core.getInput('task-comment'),
     PULL_REQUEST = github.context.payload.pull_request,
@@ -55,6 +54,7 @@ try {
       'g'
     );
   let taskComment = null,
+    targets = TARGETS? JSON.parse(TARGETS) : [],
     parseAsanaURL = null;
 
   if (!ASANA_PAT){
@@ -66,9 +66,9 @@ try {
   while ((parseAsanaURL = REGEX.exec(PULL_REQUEST.body)) !== null) {
     let taskId = parseAsanaURL.groups.task;
     if (taskId) {
-      asanaOperations(ASANA_PAT, PROJECT_NAME, taskId, SECTION_NAME, taskComment);
+      asanaOperations(ASANA_PAT, targets, taskId, taskComment);
     } else {
-      core.info('Invalid Asana task URL after the trigger phrase' + TRIGGER_PHRASE);
+      core.info(`Invalid Asana task URL after the trigger phrase ${TRIGGER_PHRASE}`);
     }
   }
 } catch (error) {

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const asana = require('asana');
 
 async function asanaOperations(
   asanaPAT,
-  projectId,
+  projectName,
   taskId,
   sectionName,
   taskComment
@@ -14,20 +14,24 @@ async function asanaOperations(
       defaultHeaders: { 'asana-enable': 'new-sections,string_ids' },
       logAsanaChangeWarnings: false
     }).useAccessToken(asanaPAT);
-    if (sectionName) {
-      let project = await client.sections.findByProject(projectId);
-      if (project) {
-        let requiredSection = project.find(data => data.name === sectionName);
-        if (requiredSection) {
-          await client.sections.addTask(requiredSection.gid, { task: taskId });
-          core.info('Moved to: ' + requiredSection.name);
+
+    if (sectionName && projectName) {
+      let targetProject = await client.tasks.findById(taskId)
+        .then(task => task.projects.find(project => project.name === projectName));
+      if (targetProject) {
+        let targetSection = await client.sections.findByProject(targetProject.gid)
+          .then(sections => sections.find(section => section.name === sectionName));
+        if (targetSection) {
+          await client.sections.addTask(targetSection.gid, { task: taskId });
+          core.info('Moved to: ' + targetSection.name);
         } else {
           core.error('Asana section ' + sectionName + ' not found.');
         }
       } else {
-        core.error('Asana project with id ' + projectId + ' not found.');
+        core.error(`This task does not exist in "${projectName}" project`);
       }
     }
+
     if (taskComment) {
       await client.tasks.addComment(taskId, {
         text: taskComment
@@ -41,6 +45,7 @@ async function asanaOperations(
 
 try {
   const ASANA_PAT = core.getInput('asana-pat'),
+    PROJECT_NAME = core.getInput('target-project'),
     SECTION_NAME = core.getInput('target-section'),
     TRIGGER_PHRASE = core.getInput('trigger-phrase'),
     TASK_COMMENT = core.getInput('task-comment'),
@@ -53,16 +58,15 @@ try {
     parseAsanaURL = null;
 
   if (!ASANA_PAT){
-    throw({message: "ASANA PAT Not Found!"});
+    throw({message: 'ASANA PAT Not Found!'});
   }
   if (TASK_COMMENT) {
     taskComment = `${TASK_COMMENT} ${PULL_REQUEST.html_url}`;
   }
   while ((parseAsanaURL = REGEX.exec(PULL_REQUEST.body)) !== null) {
-    let projectId = parseAsanaURL.groups.project,
-      taskId = parseAsanaURL.groups.task;
-    if (projectId && taskId) {
-      asanaOperations(ASANA_PAT, projectId, taskId, SECTION_NAME, taskComment);
+    let taskId = parseAsanaURL.groups.task;
+    if (taskId) {
+      asanaOperations(ASANA_PAT, PROJECT_NAME, taskId, SECTION_NAME, taskComment);
     } else {
       core.info('Invalid Asana task URL after the trigger phrase' + TRIGGER_PHRASE);
     }


### PR DESCRIPTION
Add an extra parameter(`target-project`) to find the correct project. Previously it was being obtained from `projectId` given in URL of the task, as a task can belong to more than one project in this way we may not get desired `projectId` from URL. Now we are getting all projects in which given task exists and find out if task belongs to `target-project` or not. If a task belongs to `target-project` then we get all sections of this `target-project` and move the task to `target-section` if `target-section` exists in `target-project`.