### PR TITLE
add ability to include review status in comment

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,9 @@ inputs:
   task-comment:
     description: 'Provide text, which will add a comment with the pull request link to the asana task.'
     required: false
+  include-review-status:
+    description: 'When set to "true", the review status will be included in the comment posted to asana. Useful when using pull_request_review as a trigger.'
+    required: false
   targets:
     description: 'JSON array of objects having project and section where to move current task. Move task only if it exists in target project.'
     required: false

--- a/index.js
+++ b/index.js
@@ -48,6 +48,7 @@ try {
     TARGETS = core.getInput('targets'),
     TRIGGER_PHRASE = core.getInput('trigger-phrase'),
     TASK_COMMENT = core.getInput('task-comment'),
+    INCLUDE_REVIEW_STATUS = core.getInput('include-review-status'),
     PULL_REQUEST = github.context.payload.pull_request,
     REGEX = new RegExp(
       `\\*\\*${TRIGGER_PHRASE}\\*\\* \\[(.*?)\\]\\(https:\\/\\/app.asana.com\\/(\\d+)\\/(?<project>\\d+)\\/(?<task>\\d+).*?\\)`,
@@ -61,7 +62,9 @@ try {
     throw({message: 'ASANA PAT Not Found!'});
   }
   if (TASK_COMMENT) {
-    taskComment = `${TASK_COMMENT} ${PULL_REQUEST.html_url}`;
+    taskComment = TASK_COMMENT;
+    if (INCLUDE_REVIEW_STATUS) taskComment += ` ${gitub.event.review.status}`;
+    taskComment += ` ${PULL_REQUEST.html_url}`;
   }
   while ((parseAsanaURL = REGEX.exec(PULL_REQUEST.body)) !== null) {
     let taskId = parseAsanaURL.groups.task;

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ try {
     TARGETS = core.getInput('targets'),
     TRIGGER_PHRASE = core.getInput('trigger-phrase'),
     TASK_COMMENT = core.getInput('task-comment'),
-    INCLUDE_REVIEW_STATUS = core.getInput('include-review-status'),
+    INCLUDE_REVIEW_STATUS = core.getInput('include-review-status') === "true",
     PULL_REQUEST = github.context.payload.pull_request,
     REGEX = new RegExp(
       `\\*\\*${TRIGGER_PHRASE}\\*\\* \\[(.*?)\\]\\(https:\\/\\/app.asana.com\\/(\\d+)\\/(?<project>\\d+)\\/(?<task>\\d+).*?\\)`,

--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ try {
   }
   if (TASK_COMMENT) {
     taskComment = TASK_COMMENT;
-    if (INCLUDE_REVIEW_STATUS) taskComment += ` ${gitub.event.review.status}`;
+    if (INCLUDE_REVIEW_STATUS) taskComment += ` ${github.event.review.status}`;
     taskComment += ` ${PULL_REQUEST.html_url}`;
   }
   while ((parseAsanaURL = REGEX.exec(PULL_REQUEST.body)) !== null) {


### PR DESCRIPTION
I would like to create actions that add a comment to an asana task whenever a review is submitted. It would be helpful to include the review status in these comments, so I created this PR to read an optional `include-review-status` setting and, if it is present, we include the review status in the comment.