### PR TITLE
chore: bump to node v16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,5 +17,5 @@ branding:
   icon: 'chevron-right'  
   color: 'gray-dark'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'


### PR DESCRIPTION
Node 12 is deprecated and all actions will run on node16 in the near future. More info here: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/