### PR TITLE
✨ Add support for both v0 and v1 urls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "github-asana",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-asana",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Action to integrate git with asana",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Updated the Asana URL regex to support both legacy (v0) and new (v1) formats:

Old format: https://app.asana.com/0/{project_id}/{task_id}

New format: https://app.asana.com/1/{workspace_id}/project/{project_id}/task/{task_id}